### PR TITLE
Deterministic output for flattened properties

### DIFF
--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -302,7 +302,8 @@ func (g *packageGenerator) genResource(typeName string, createMethod, getMethod,
 		var flatten string
 		createRequest := g.rest.Schemas[createMethod.Request.Ref]
 		if getMethod != nil && createMethod.Request.Ref != getMethod.Response.Ref {
-			for name, v := range createRequest.Properties {
+			for _, name := range codegen.SortedKeys(createRequest.Properties) {
+				v := createRequest.Properties[name]
 				if v.Ref == getMethod.Response.Ref {
 					flatten = name
 				}
@@ -327,7 +328,8 @@ func (g *packageGenerator) genResource(typeName string, createMethod, getMethod,
 			var updateFlatten string
 			updateRequest := g.rest.Schemas[updateMethod.Request.Ref]
 			if getMethod != nil && updateMethod.Request.Ref != getMethod.Response.Ref {
-				for name, v := range updateRequest.Properties {
+				for _, name := range codegen.SortedKeys(updateRequest.Properties) {
+					v := updateRequest.Properties[name]
 					if v.Ref == getMethod.Response.Ref {
 						updateFlatten = name
 					}


### PR DESCRIPTION
If there is a collision between parent properties and flattened properties, the resulting metadata is non-deterministic. This enforces an ordering but does so arbitrarily. Not sure how we want to handle this - we could introduce an `sdkName` equivalent to distinguish them. We should discuss solving that in a separate ticket: https://github.com/pulumi/pulumi-gcp-native/issues/31