### PR TITLE
Delete for non-deletable resources

### DIFF
--- a/provider/cmd/pulumi-resource-gcp-native/metadata.json
+++ b/provider/cmd/pulumi-resource-gcp-native/metadata.json
@@ -32102,8 +32102,7 @@
                 "projectsId",
                 "instancesId",
                 "databasesId"
-            ],
-            "noDelete": true
+            ]
         },
         "gcp-native:spanner/v1:InstanceDatabaseIamPolicy": {
             "baseUrl": "https://spanner.googleapis.com/",

--- a/provider/pkg/gen/schema.go
+++ b/provider/pkg/gen/schema.go
@@ -214,7 +214,7 @@ func (g *packageGenerator) findResources(parent string, resources map[string]dis
 						return err
 					}
 				}
-			case "delete":
+			case "delete", "dropDatabase" /*special case for Spanner Database*/ :
 				deleteMethod = &restMethod
 			}
 		}


### PR DESCRIPTION
I went through the list of resources that we mark as "NoDelete" and found only one case of a different naming: `dropDatabase` for Spanner (added an exception). There are also some "cancel", "disable", etc. methods that we may want to invoke as deletes - but they are all single cases without any apparent rule.

I found that the classic GCP provider already has 10 resources that are only deleted from the state but not from GCP - so I went ahead and added a warning of this kind to the code. We can refine this later after the initial preview.

Finally, I added a special case for IamPolicy resources: invoke an update with an empty body. IamPolicy resources have awkward IDs ending with `:getIamPolicy`. I coded around this in the provider code for now, let's see if there are any other resources like this and find an encoding in metadata if needed.